### PR TITLE
Fix flash header size check and GDS brute check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,4 +60,4 @@ script:
   - python ./tests/test_compression.py
 
   # Run a test script against all samples
-  - python ./samples/test_samples.py
+  - (cd samples && python ./test_samples.py)

--- a/uefi_firmware/flash.py
+++ b/uefi_firmware/flash.py
@@ -83,15 +83,15 @@ class FlashRegion(FirmwareObject, BaseObject):
 
 class FlashDescriptor(FirmwareObject):
     def __init__(self, data):
-        self.padding, self.header = struct.unpack("<16s4s", data[:16 + 4])
-        #print self.header.encode("hex")
-
-        self.valid_header = True
-        if self.header != FLASH_HEADER:
-            #print_error("Error: Invalid flash descriptor header.")
-            self.valid_header = False
+        self.valid_header = False
+        if len(data) < 20:
             return
 
+        self.padding, self.header = struct.unpack("<16s4s", data[:16 + 4])
+        if self.header != FLASH_HEADER:
+            return
+
+        self.valid_header = True
         self.regions = []
         self.data = data
 

--- a/uefi_firmware/pfs.py
+++ b/uefi_firmware/pfs.py
@@ -149,6 +149,9 @@ class PFSFile(FirmwareObject):
     def __init__(self, data):
         self.sections = []
         self.data = data
+        self.valid_header = False
+        if self.check_header():
+            self.valid_header = True
 
     def check_header(self):
         if len(self.data) < 32:
@@ -191,6 +194,7 @@ class PFSFile(FirmwareObject):
 
             if len(data) < 64:
                 break
+        return True
 
     @property
     def objects(self):

--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -497,8 +497,8 @@ class GuidDefinedSection(EfiSection):
         elif sguid(self.guid) == FIRMWARE_GUIDED_GUIDS["FIRMWARE_VOLUME"]:
             status = parse_volume()
         else:
-            ### Undefined GUIDed-Section GUID, treat as a FV?
-            status = parse_volume()
+            ### Undefined GUIDed-Section GUID, treat as a FV, don't require status
+            parse_volume()
         return status
         pass
 


### PR DESCRIPTION
Fixes a flash header size assumption, a PFS regression where the header wasn't checked, and a UEFI invalid process status (when a GDS tries to brute-force find a FV).
