### PR TITLE
Remove end argument to print

### DIFF
--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -1130,9 +1130,9 @@ class FirmwareVolume(FirmwareObject):
             self.size,
             self.size
         ))
-        print (blue("%s  Firmware Volume Blocks: " % (ts)), end=False)
+        print (blue("%s  Firmware Volume Blocks: " % (ts)))
         for block_size, block_length in self.blocks:
-            print ("(%d, 0x%x)" % (block_size, block_length), end=False)
+            print ("(%d, 0x%x)" % (block_size, block_length))
         print ("")
 
         for _ffs in self.firmware_filesystems:


### PR DESCRIPTION
This removed the incorrect bools values from end. This code-path is triggered for certain Dell updates. These updates should constitute a new PFS-like type where certain NVRAM values are pre-pended to the update.