### PR TITLE
Unify output types as strings or hex

### DIFF
--- a/uefi_firmware/flash.py
+++ b/uefi_firmware/flash.py
@@ -70,7 +70,7 @@ class FlashRegion(FirmwareObject, BaseObject):
         print "%s%s type= %s, size= 0x%x (%d bytes) details[ %s ]" % (
             ts, blue("Flash Region"), green(self.name),
             len(self.data), len(self.data),
-            ", ".join(["%s: %s" % (k, v) for k, v in self.attrs.iteritems()])
+            ", ".join(["%s: 0x%02x" % (k, v) for k, v in self.attrs.iteritems()])
         )
         for section in self.sections:
             section.showinfo(ts="%s  " % ts)
@@ -182,8 +182,8 @@ class FlashDescriptor(FirmwareObject):
         return True
 
     def showinfo(self, ts='', index=None):
-        print (("%s%s chips %d, regions %d, masters %d, PCH straps %d, "
-                "PROC straps %d, ICC entries %d") % (
+        print (("%s%s chips 0x%02x, regions 0x%02x, masters 0x%02x, PCH straps 0x%02x, "
+                "PROC straps 0x%02x, ICC entries 0x%02x") % (
             ts, blue("Flash Descriptor (Intel PCH)"),
             self.map.structure.NumberOfFlashChips,
             self.map.structure.NumberOfRegions,

--- a/uefi_firmware/pfs.py
+++ b/uefi_firmware/pfs.py
@@ -203,9 +203,10 @@ class PFSSection(FirmwareObject, BaseObject):
         pass
 
     def showinfo(self, ts='', index=None):
-        print "%s%s %s spec %d version %s size 0x%x (%d bytes)" % (
+        print "%s%s %s spec 0x%02x ts 0x%02x type 0x%02x version 0x%02x size 0x%x (%d bytes)" % (
             ts, blue("Dell PFSSection:"), green(sguid(self.uuid)),
-            self.spec, self.version, self.section_size, self.section_size
+            self.spec, self.ts, self.type, self.version,
+            self.section_size, self.section_size
         )
 
         for sub_object in self.section_objects:


### PR DESCRIPTION
Consistency with types is helpful moving forward. This might break any scraping of the output, but in those cases the correct way forward is using the various `.info` methods.
