### PR TITLE
Extract PDR section of Flash

### DIFF
--- a/uefi_firmware/flash.py
+++ b/uefi_firmware/flash.py
@@ -163,6 +163,18 @@ class FlashDescriptor(FirmwareObject):
         })
         gbe_region.process()
         self.regions.append(gbe_region)
+        
+        pdr_base = self.region.structure.PdrBase
+        pdr_limit = self.region.structure.PdrLimit
+        pdr_size = _region_offset(pdr_base) + _region_size(pdr_base, pdr_limit)
+        pdr = self.data[_region_offset(pdr_base): pdr_size]
+
+        pdr_region = FlashRegion(pdr, "pdr", {
+            "base": pdr_base,
+            "limit": pdr_limit,
+        })
+        pdr_region.process()
+        self.regions.append(pdr_region)
         return True
 
     def showinfo(self, ts='', index=None):


### PR DESCRIPTION
FlashRegionSectionType already parses PdrBase and PdrLimit. This bit of the code just makes sure that FlashDescriptor uses that information to actually extract that region out.

I've tested this against a BIOS that has PDR section and it seems to work fine:
```
pparth@doctor:/tmp/uefi-firmware-parser/regions$ ls -al
drwxr-x---  3 pparth eng     4096 Feb 18 16:58 region-bios
-rw-r-----  1 pparth eng 11468800 Feb 18 16:58 region-bios.fd
-rw-r-----  1 pparth eng     8192 Feb 18 16:58 region-gbe.fd
-rw-r-----  1 pparth eng  5287936 Feb 18 16:58 region-me.fd
-rw-r-----  1 pparth eng     8192 Feb 18 16:58 region-pdr.fd
pparth@doctor:~/tmp/uefi-firmware-parser/regions$ 
```

8192 bytes for the PDR region is correct - confirmed by extracting using UEFIExtract:
```
pparth@doctor:/tmp/uefiextract/bios.dump/2 PDR region$ ls -al
-rw-r----- 1 pparth eng 8192 Feb 18 17:01 body.bin
-rw-r----- 1 pparth eng   49 Feb 18 17:01 info.txt
pparth@doctor:/tmp/uefiextract/bios.dump/2 PDR region$ cat info.txt 
Type: Region
Subtype: PDR
Full size: 2000h (8192)
```

Diff confirms that the outputs between UEFIExtract and uefi_firmware are identical :)