### PR TITLE
Include ME objects

### DIFF
--- a/uefi_firmware/me.py
+++ b/uefi_firmware/me.py
@@ -590,6 +590,12 @@ class PartitionEntry(MeObject):
             self.has_content = False
         self.data = data[self.structure.Offset:partition_end]
 
+    @property
+    def objects(self):
+        if self.manifest is not None:
+            return [self.manifest]
+        return []
+
     def process(self):
         if not self.has_content:
             return True


### PR DESCRIPTION
Previously, the ME `PartitionEntry` did not include the embedded manifest object. This meant object enumeration would stop before any manifest/module/entries were seen or counted.