### PR TITLE
[Fix #44] --brute and add --superbrute

### DIFF
--- a/scripts/fv_parser.py
+++ b/scripts/fv_parser.py
@@ -17,6 +17,15 @@ def _process_show_extract(parsed_object):
         parsed_object.dump(args.output)
 
 
+def superbrute_search(data):
+    for i in xrange(len(data)):
+        bdata = data[i:]
+        parser = AutoParser(bdata)
+        if parser.type() is not 'unknown':
+            _process_show_extract(parser.parse())
+            break
+
+
 def brute_search_volumes(data):
     volumes = search_firmware_volumes(data)
     for index in volumes:
@@ -44,6 +53,9 @@ if __name__ == "__main__":
     parser.add_argument(
         '-b', "--brute", action="store_true",
         help='The input is a blob and may contain FV headers.')
+    parser.add_argument(
+        '--superbrute', action="store_true",
+        help='The input is a blob and may contain any sort of firmware object')
 
     parser.add_argument('-q', "--quiet",
                         default=False, action="store_true", help="Do not show info.")
@@ -64,6 +76,10 @@ if __name__ == "__main__":
                 input_data = fh.read()
         except Exception, e:
             print "Error: Cannot read file (%s) (%s)." % (file_name, str(e))
+            continue
+
+        if args.superbrute:
+            superbrute_search(input_data)
             continue
 
         if args.brute:

--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -1035,13 +1035,15 @@ class FirmwareVolume(FirmwareObject):
     block_map = None
     '''list: An empty block set.'''
 
-    firmware_filesystems = None
+    firmware_filesystems = []
     '''list: Set of FirmwareFileSystems discovered in volume.'''
 
-    raw_objects = None
+    raw_objects = []
     '''list: Set of RawObjects discovered in volume.'''
 
     def __init__(self, data, name="volume"):
+        self.firmware_filesystems = []
+        self.raw_objects = []
         self.name = name
         self.valid_header = False
 


### PR DESCRIPTION
For firmware updates that include headers, where the content is not compressed the `--superbrute` will attempt to find the first "firmware"-like object then parse and return.