### PR TITLE
[Fix #53] Add 'basic' Lenovo Phoenix (fl1) parsing

### DIFF
--- a/bin/uefi-firmware-parser
+++ b/bin/uefi-firmware-parser
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import logging
 import os
 
 from uefi_firmware.uefi import *
@@ -44,8 +45,9 @@ def brute_search_volumes(data):
 
 def parse_firmware_volume(data, name=0):
     firmware_volume = FirmwareVolume(data, name)
-    if not firmware_volume.valid_header:
+    if not firmware_volume.valid_header or not firmware_volume.process():
         return
+    print("Found volume magic at 0x%x" % name)
     _process_show_extract(firmware_volume)
 
     if args.generate is not None:
@@ -87,10 +89,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "--test", default=False, action='store_true',
         help="Test file parsing, output name/success.")
+    parser.add_argument('--verbose', default=False, action='store_true',
+        help='Enable verbose logging while parsing')
     parser.add_argument(
         "file", nargs='+',
         help="The file(s) to work on")
     args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+    else:
+        logging.basicConfig(level=logging.WARNING)
 
     for file_name in args.file:
         FILENAME = file_name
@@ -112,7 +121,7 @@ if __name__ == "__main__":
             brute_search_volumes(input_data)
             continue
 
-        parser = AutoParser(input_data)
+        parser = AutoParser(input_data, search=True)
         if args.test:
             print "%s: %s" % (file_name, red(parser.type()))
             continue

--- a/uefi_firmware/base.py
+++ b/uefi_firmware/base.py
@@ -139,6 +139,7 @@ class RawObject(FirmwareObject, BaseObject):
 
     def __init__(self, data):
         self.data = data
+        self.size = len(data)
 
     def build(self, generate_checksum, debug=False):
         return self.data
@@ -148,8 +149,8 @@ class RawObject(FirmwareObject, BaseObject):
             ts, blue("RawObject:"), len(self.data)
         ))
 
-    def dump(self, parent='', index=None):
-        path = os.path.join(parent, "object.raw")
+    def dump(self, parent='', index=0):
+        path = os.path.join(parent, "object-%s.raw" % (str(index)))
         dump_data(path, self.data)
 
 
@@ -171,6 +172,7 @@ class AutoRawObject(RawObject):
         from . import AutoParser
         parser = AutoParser(self.data)
         self.object = parser.parse()
+        return self.object is not None
 
     def showinfo(self, ts='', index=None):
         if self.object is None:

--- a/uefi_firmware/flash.py
+++ b/uefi_firmware/flash.py
@@ -90,7 +90,8 @@ class FlashDescriptor(FirmwareObject):
 
     def __init__(self, data):
         self.valid_header = False
-        if len(data) < 20:
+        self.size = len(data)
+        if self.size < 20:
             return
 
         self.padding, self.header = struct.unpack("<16s4s", data[:16 + 4])

--- a/uefi_firmware/misc/checker.py
+++ b/uefi_firmware/misc/checker.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import re
 
 from ..uefi import FirmwareVolume, FirmwareCapsule
-from ..pfs import PFSFile
+from ..pfs import PFSFile, PFHeader
 from ..flash import FlashDescriptor
 from ..me import MeContainer, MeManifestHeader
 
@@ -72,6 +72,14 @@ class IntelMETester(TypeTester):
         return me.valid_header
 
 
+class PFHeaderTester(TypeTester):
+    parser = PFHeader
+
+    def match(self, data):
+        pfh = PFHeader(data)
+        return pfh.valid_header
+
+
 class DellPFSTester(TypeTester):
     static = "PFS.HDR"
     parser = PFSFile
@@ -89,7 +97,6 @@ class DellUpdateBinaryTester(TypeTester):
         return True
 
 TESTERS = [
-    UEFIFirmwareVolumeTester,
     FlashDescriptorTester,
     UEFICapsuleTester,
     EFICapsuleTester,
@@ -97,4 +104,6 @@ TESTERS = [
     IntelMETester,
     DellPFSTester,
     DellUpdateBinaryTester,
+    PFHeaderTester,
+    UEFIFirmwareVolumeTester,
 ]

--- a/uefi_firmware/structs/uefi_structs.py
+++ b/uefi_firmware/structs/uefi_structs.py
@@ -16,6 +16,8 @@ FIRMWARE_VOLUME_GUIDS = {
     "NVRAM_NVAR":  "cef5b9a3-476d-497f-9fdc-e98143e0422c",
     "NVRAM_EVSA2": "00504624-8a59-4eeb-bd0f-6b36e96128e0",
     "APPLE_BOOT":  "04adeead-61ff-4d31-b6ba-64f8bf901f5a",
+    "PFH1":        "16b45da2-7d70-4aea-a58d-760e9ecb841d",
+    "PFH2":        "e360bdba-c3ce-46be-8f37-b231e5cb9f35",
     #'08758b38-458d-50e8-56e8-3bffffff83c4'
 }
 


### PR DESCRIPTION
There's a weak attempt to scan past `0xFF` until the first `TypeTester` match to accommodate the layout for Lenovo Phoenix `.fl1` files. The `AutoParser` wraps output in a `MultiObject` if there is content before, or after the parsed object-- or if there were side-by-side objects.

To help trace error in `.process()` a `--verbose` flag is added.