### PR TITLE
README correction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Please use the example scripts for parsing tutorials.
 Installation
 ------------
 
-This module is included within PyPy as `uefi_firmware <https://pypi.python.org/pypi/uefi_firmware>`_
+This module is available through PyPi as `uefi_firmware <https://pypi.python.org/pypi/uefi_firmware>`_
 
 ::
 


### PR DESCRIPTION
Small mistake in the README: "PyPi" was written "PyPy" (a slightly different thing. :)

I also made the language a little nicer.