### PR TITLE
Add option to parse raw DEPEX binary

### DIFF
--- a/bin/uefi-firmware-parser
+++ b/bin/uefi-firmware-parser
@@ -85,6 +85,9 @@ if __name__ == "__main__":
     argparser.add_argument(
         '--superbrute', default=False, action="store_true",
         help='The input is a blob and may contain any sort of firmware object')
+    argparser.add_argument(
+        '--depex', default=False, action="store_true",
+        help='The input is a DEPEX blob')
 
     argparser.add_argument(
         '-q', "--quiet", default=False, action="store_true",
@@ -142,6 +145,18 @@ if __name__ == "__main__":
         except Exception as e:
             print("Error: Cannot read file (%s) (%s)." % (file_name, str(e)))
             errcode = max(errcode, 1)
+            continue
+
+        if args.depex:
+            depex = parse_depex(input_data)
+            for op in depex:
+                if 'guid' in op:
+                    if 'name' in op and op['name'] is not None:
+                        print("{} {} ({})".format(op['op'], op['guid'], op['name']))
+                    else:
+                        print("{} {}".format(op['op'], op['guid']))
+                else:
+                    print("{}".format(op['op']))
             continue
 
         if args.superbrute:

--- a/uefi_firmware/guids/__init__.py
+++ b/uefi_firmware/guids/__init__.py
@@ -16,7 +16,7 @@ GUID_TABLES = [
 
 
 def get_guid_name(guid):
-    raw_guid = aguid(guid) if isinstance(guid, str) else guid
+    raw_guid = aguid(guid)
 
     for guid_table in GUID_TABLES:
         for name, match_guid in list(guid_table.items()):


### PR DESCRIPTION
When a proprietary DXE is distributed in binary form, the DEPEX also has
to be distributed. They're included in the EDK2 FDF file like this:

```
FILE DRIVER = E8AB593A-9E3F-42A5-829E-E1E4843A0B13 {
   SECTION DXE_DEPEX = FooDxe.depex
   SECTION PE32 = FooDxe.efi
   SECTION UI = "FooDxe"
}
```

Too dump the contents of the DEPEX you can run the command like this:

```
$ uefi-firmware-parse --depex FooDxe.depex
PUSH 06219C7A-9CCB-4292-8D6E-79A157C3EBBB
PUSH 665e3ff6-46cc-11d4-9a38-0090273fc14d (EFI_BDS_ARCH_PROTOCOL_GUID)
AND
END
```

The first GUID is unknown, the second one is known, therefore ufp can print the name.