### PR TITLE
Add release pipeline, fixes #116

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,35 @@ name: Build release artifacts
 on: [push, pull_request]
 
 jobs:
-  build_wheels:
-    name: Build artifacts
+  build_sdist:
+    name: Build sdist
     runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      # Used to host build
+      - name: Setup Python
+        uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install build==0.10.0
+
+      - name: Build sdist
+        run: python -m build -s -o dist
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: ./dist/*
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - name: Checkout source
@@ -16,10 +42,7 @@ jobs:
         uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.14.1 build==0.10.0
-
-      - name: Build sdist
-        run: python -m build -s -o dist
+        run: python -m pip install cibuildwheel==2.14.1
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
@@ -27,11 +50,22 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
+          name: wheels-${{ matrix.os }}
           path: ./dist/*
 
-      - name: Publish package distributions to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+  publish_pypi:
+    name: Publish artifacts to PyPI
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
         with:
-          packages-dir: dist/
+          path: dist
+
+      - name: Flatten dist directory
+        run: find dist -type f -exec mv -f {} dist/ \; -exec sh -c 'rmdir "$(dirname "$1")"' _ {} \;
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Build release artifacts
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build artifacts
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      # Used to host cibuildwheel
+      - name: Setup Python
+        uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.14.1 build==0.10.0
+
+      - name: Build sdist
+        run: python -m build -s -o dist
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./dist/*
+
+      - name: Publish package distributions to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
     name: Publish artifacts to PyPI
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [build_sdist, build_wheels]
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: [build_sdist, build_wheels]
+    permissions:
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install build==0.10.0
+        run: python -m pip install build>=0.10.0
 
       - name: Build sdist
         run: python -m build -s -o dist
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.14.1
+        run: python -m pip install cibuildwheel>=2.14.1
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
 
-      - name: Install cibuildwheel
+      - name: Install python-build
         run: python -m pip install build>=0.10.0
 
       - name: Build sdist
@@ -46,6 +46,10 @@ jobs:
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"
+          CIBW_ARCHS_WINDOWS: "AMD64 x86 ARM64"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
+      # Used for aarch64 build on linux
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        if: contains(matrix.os, 'ubuntu')
+
       # Used to host cibuildwheel
       - name: Setup Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
This release pipeline uses cibuildwheel to build wheels for most common platforms and also an sdist for platforms not covered. All the build tools and publishing action are by PyPA to hopefully observe best practices. One notable thing is that this does not generate a python 2 wheel, however python 2 users will still be able to install with the provided sdist. If that is an issue I can look at adding another set of jobs for python 2 specifically using an older version of cibuildwheel.

I have tested the build jobs and the output looks good, I haven't been able to validate the publish job. In order for the upload to succeed, you'll need to configure a trusted publisher as documented [here](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).

Fixes #116 