### PR TITLE
Add support for AMD compressed sections

### DIFF
--- a/uefi_firmware/structs/uefi_structs.py
+++ b/uefi_firmware/structs/uefi_structs.py
@@ -29,13 +29,14 @@ FIRMWARE_CAPSULE_GUIDS = [
 ]
 
 FIRMWARE_GUIDED_GUIDS = {
-    "LZMA_COMPRESSED":    "ee4e5898-3914-4259-9d6e-dc7bd79403cf",
-    "LZMA_COMPRESSED_HP": "0ed85e23-f253-413f-a03c-901987b04397",
-    "TIANO_COMPRESSED":   "a31280ad-481e-41b6-95e8-127f4c984779",
-    "FIRMWARE_VOLUME":    "24400798-3807-4a42-b413-a1ecee205dd8",
-    #"VOLUME_SECTION":    "367ae684-335d-4671-a16d-899dbfea6b88",
-    "STATIC_GUID":        "fc1bcdb0-7d31-49aa-936a-a4600d9dd083",
-    "ZLIB_COMPRESSED_QC": "1d301fe9-be79-4353-91c2-d23bc959ae0c"
+    "LZMA_COMPRESSED":     "ee4e5898-3914-4259-9d6e-dc7bd79403cf",
+    "LZMA_COMPRESSED_HP":  "0ed85e23-f253-413f-a03c-901987b04397",
+    "TIANO_COMPRESSED":    "a31280ad-481e-41b6-95e8-127f4c984779",
+    "FIRMWARE_VOLUME":     "24400798-3807-4a42-b413-a1ecee205dd8",
+    #"VOLUME_SECTION":     "367ae684-335d-4671-a16d-899dbfea6b88",
+    "STATIC_GUID":         "fc1bcdb0-7d31-49aa-936a-a4600d9dd083",
+    "ZLIB_COMPRESSED_QC":  "1d301fe9-be79-4353-91c2-d23bc959ae0c",
+    "ZLIB_COMPRESSED_AMD": "ce3233f5-2cd6-4d87-9152-4a238bb6d1c4",
 }
 
 FIRMWARE_FREEFORM_GUIDS = {
@@ -196,4 +197,12 @@ class FirmwareVolumeType(ctypes.LittleEndianStructure):
         ("Checksum",   uint16_t),
         ("Reserved2",  uint8_t),
         ("Revision",   uint8_t)
+    ]
+
+class EfiAmdZlibSectionHeader(ctypes.LittleEndianStructure):
+    _pack_ = 1
+    _fields_ = [
+        ("ZeroHeader", uint8_t * 0x14),
+        ("CompressedSize", uint32_t),
+        ("ZeroFooter", uint8_t * (0x100 - 0x14 - 4))   
     ]


### PR DESCRIPTION
This PR adds support for unpacking firmware containing AMD compressed sections.
Initially section with GUID `ce3233f5-2cd6-4d87-9152-4a238bb6d1c4` was not processed.

For the reference:
* https://github.com/LongSoft/UEFITool/blob/4a41c33596e9bc3ae812e763965d91ac57553e02/common/ffsparser.cpp#L2383
* https://github.com/LongSoft/UEFITool/blob/4a41c33596e9bc3ae812e763965d91ac57553e02/common/ffsparser.cpp#L2912
* https://github.com/LongSoft/UEFITool/blob/4a41c33596e9bc3ae812e763965d91ac57553e02/common/ffs.h#L457


Test firmware can be downloaded here: https://www.gigabyte.com/Mini-PcBarebone/GB-BER5-5500-rev-10/support#support-dl-bios.

Result:

```
...
  File 7: 3e3b6dc0-064d-4b01-9203-7836c9b498e7 type 0x0b, attr 0x04, state 0x07, size 0x77b7a (490362 bytes), (firmware volume image)
    Section 0: type 0x02, size 0x77b62 (490338 bytes) (Guid Defined section)
      Guid-Defined: ce3233f5-2cd6-4d87-9152-4a238bb6d1c4 offset= 0x18 attrs= 0x1 (PROCESSING_REQUIRED)
        Section 0: type 0x19, size 0x1c (28 bytes) (Raw section)
        Section 1: type 0x17, size 0x400004 (4194308 bytes) (Firmware volume image section)
          Firmware Volume: 8c8ce578-8a3d-4f1c-9935-896185c32dd3 attr 0x0005feff, rev 2, cksum 0xe22e, size 0x400000 (4194304 bytes)
            Firmware Volume Blocks: (1024, 0x1000)
            File 0: ffffffff-ffff-ffff-ffff-ffffffffffff type 0xf0, attr 0x00, state 0x07, size 0x2c (44 bytes), (ffs padding)
            File 1: 1b45cc0a-156a-428a-af62-49864da0e6e6 (EFI_PEI_APRIORI_FILE_NAME_GUID) type 0x02, attr 0x00, state 0x07, size 0xac (172 bytes), (freeform)
              Section 0: type 0x19, size 0x94 (148 bytes) (Raw section)
            File 2: 5b85965c-455d-4cc6-9c4c-7f086967d2b0 type 0x02, attr 0x00, state 0x07, size 0x3c (60 bytes), (freeform)
              Section 0: type 0x19, size 0x24 (36 bytes) (Raw section)
            File 3: 76864548-0261-410e-a8b4-01615bfa3e0a type 0x06, attr 0x00, state 0x07, size 0x6de (1758 bytes), (pei module)
              Section 0: type 0x1b, size 0x28 (40 bytes) (PEI dependency expression section)
                PUSH EFI_PEI_PERMANENT_MEMORY_INSTALLED_PPI_GUID (f894643d-c449-42d1-8ea8-85bdd8c65bde)
                PUSH EFI_PEI_PCD_PPI_GUID (01f34d25-4de2-23ad-3ff3-36353ff323f1)
                AND
                END
              Section 1: type 0x12, size 0x674 (1652 bytes) (Terse executable (TE) section)
              Section 2: type 0x15, size 0x1c (28 bytes) (User interface name section)
              Name: FwKeyHobPei
              Section 3: type 0x14, size 0xe (14 bytes) (Version section section)
            File 4: 7eb7126d-c45e-4bd0-9357-7f507c5c9cf9 type 0x06, attr 0x00, state 0x07, size 0x12a2 (4770 bytes), (pei module)
              Section 0: type 0x1b, size 0x16 (22 bytes) (PEI dependency expression section)
                PUSH EFI_PEI_PCD_PPI_GUID (01f34d25-4de2-23ad-3ff3-36353ff323f1)
                END
              Section 1: type 0x12, size 0x1244 (4676 bytes) (Terse executable (TE) section)
              Section 2: type 0x15, size 0x1e (30 bytes) (User interface name section)
              Name: RomLayoutPei
              Section 3: type 0x14, size 0xe (14 bytes) (Version section section)
            File 5: 52c05b14-0b98-496c-bc3b-04b50211d680 (LENOVO_PEI_MAIN_GUID) type 0x04, attr 0x00, state 0x07, size 0x593e (22846 bytes), (pei core)
              Section 0: type 0x12, size 0x5904 (22788 bytes) (Terse executable (TE) section)
              Section 1: type 0x15, size 0x14 (20 bytes) (User interface name section)
              Name: PeiCore
              Section 2: type 0x14, size 0xe (14 bytes) (Version section section)
            File 6: c779f6d8-7113-4aa1-9648-eb1633c7d53b type 0x06, attr 0x00, state 0x07, size 0x1dce (7630 bytes), (pei module)
              Section 0: type 0x1b, size 0x28 (40 bytes) (PEI dependency expression section)
                PUSH EFI_PEI_READ_ONLY_VARIABLE2_PPI_GUID (2ab86ef5-ecb5-4134-b556-3854ca1fe1b4)
                PUSH EFI_PEI_PCD_PPI_GUID (01f34d25-4de2-23ad-3ff3-36353ff323f1)
                AND
                END
              Section 1: type 0x12, size 0x1d64 (7524 bytes) (Terse executable (TE) section)
              Section 2: type 0x15, size 0x1a (26 bytes) (User interface name section)
              Name: CapsulePei
              Section 3: type 0x14, size 0xe (14 bytes) (Version section section)
            File 7: 86d70125-baa3-4296-a62f-602bebbb9081 type 0x06, attr 0x00, state 0x07, size 0x3d5a (15706 bytes), (pei module)
              Section 0: type 0x1b, size 0x3a (58 bytes) (PEI dependency expression section)
                PUSH EFI_PEI_LOAD_FILE_GUID (b9e0abfe-5979-4914-977f-6dee78c278a6)
                PUSH 7408d748-fc8c-4ee6-9288-c4bec092a410
                PUSH EFI_PEI_PCD_PPI_GUID (01f34d25-4de2-23ad-3ff3-36353ff323f1)
                AND
                AND
                END
              Section 1: type 0x12, size 0x3ce4 (15588 bytes) (Terse executable (TE) section)
              Section 2: type 0x15, size 0x12 (18 bytes) (User interface name section)
              Name: DxeIpl
              Section 3: type 0x14, size 0xe (14 bytes) (Version section section)
            File 8: ae265864-cf5d-41a8-913d-71c155e76442 type 0x06, attr 0x00, state 0x07, size 0x8fa (2298 bytes), (pei module)
              Section 0: type 0x1b, size 0x16 (22 bytes) (PEI dependency expression section)
                PUSH EFI_PEI_PCD_PPI_GUID (01f34d25-4de2-23ad-3ff3-36353ff323f1)
                END
              Section 1: type 0x12, size 0x8a4 (2212 bytes) (Terse executable (TE) section)
              Section 2: type 0x15, size 0x16 (22 bytes) (User interface name section)
              Name: CpuIoPei
              Section 3: type 0x14, size 0xe (14 bytes) (Version section section)
            File 9: 2bb5afa9-ff33-417b-8497-cb773c2b93bf (DELL_CPU_PEI_GUID) type 0x06, attr 0x00, state 0x07, size 0xb5e (2910 bytes), (pei module)
              Section 0: type 0x1b, size 0x16 (22 bytes) (PEI dependency expression section)
                PUSH EFI_PEI_PCD_PPI_GUID (01f34d25-4de2-23ad-3ff3-36353ff323f1)
                END
              Section 1: type 0x12, size 0xb0c (2828 bytes) (Terse executable (TE) section)
              Section 2: type 0x15, size 0x12 (18 bytes) (User interface name section)
              Name: CpuPei
              Section 3: type 0x14, size 0xe (14 bytes) (Version section section)
...
```