### PR TITLE
skip unprocessed guid defined sections

### DIFF
--- a/bin/uefi-firmware-parser
+++ b/bin/uefi-firmware-parser
@@ -14,6 +14,9 @@ from uefi_firmware import AutoParser
 import uefi_firmware.utils # import nocolor
 
 def _process_show_extract(parsed_object):
+    if parsed_object is None:
+        return
+
     global FILENAME
     if not args.quiet:
         parsed_object.showinfo('')

--- a/uefi_firmware/__init__.py
+++ b/uefi_firmware/__init__.py
@@ -3,9 +3,6 @@
 import os
 
 from . import uefi
-from . import pfs
-from . import me
-from . import flash
 
 from .misc import checker
 from .base import FirmwareObject, RawObject, AutoRawObject

--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -850,6 +850,9 @@ class FirmwareFileSystemSection(EfiSection):
             if raw_object:
                 self.parsed_object = RawObject(self.data)
                 status = True
+            elif isinstance(self.parsed_object, GuidDefinedSection):
+                self.parsed_object = None
+                return True
         return status
 
     def build(self, generate_checksum=False, debug=False):
@@ -872,7 +875,6 @@ class FirmwareFileSystemSection(EfiSection):
         string_size = struct.pack("<I", size)
         header = struct.pack("<3sB", string_size[:3], self.type)
         return size, header + data
-        pass
 
     def showinfo(self, ts='', index=-1):
         print ("%s type 0x%02x, size 0x%x (%d bytes) (%s section)" % (

--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -1186,11 +1186,11 @@ class FirmwareFile(FirmwareObject):
         return data[:4] == "\x01\x00\x00\x00" and data[20:24] == "\x01\x00\x00\x00"
 
     def _guessinfo_dict(self, data):
-        if _is_ucode(data):
+        if self._is_ucode(data):
             return "Might contain CPU microcodes"
 
     def _guessinfo_text(self, ts, data, index="N/A"):
-        if _is_ucode(data):
+        if self._is_ucode(data):
             print ("%s Might contain CPU microcodes" % (
                 blue("%sBlob %d:" % (ts, index))))
 


### PR DESCRIPTION
This PR contains fix for #123 (if at least one GuidDefinedSection has not been processed, we can skip it).
On test example it happened only with `0393d0c4-6b0c-4b96-b4c3-8c7eb718f348` (1 from 329).