### PR TITLE
Fixed a crash while handling non-UTF-8 encoded partition entry names in ME region (extension of #118)

### DIFF
--- a/uefi_firmware/base.py
+++ b/uefi_firmware/base.py
@@ -5,7 +5,7 @@
 import os
 import ctypes
 
-from .utils import dump_data, sguid, blue
+from .utils import dump_data, sguid, blue, utf8_decode_safe
 
 
 class BaseObject(object):
@@ -27,10 +27,7 @@ class FirmwareObject(object):
     @name.setter
     def name(self, name):
         if isinstance(name, bytes):
-            try:
-                name = name.decode("utf-8")
-            except UnicodeDecodeError:
-                name = "0x[{}]".format(name.hex())
+            name = utf8_decode_safe(name)
         self._name = name
 
     @property

--- a/uefi_firmware/me.py
+++ b/uefi_firmware/me.py
@@ -356,7 +356,7 @@ class MeManifestHeader(MeObject):
         print("%s%s type= %d, subtype= %d, partition name= %s" % (
             ts, blue("ME Module Manifest"),
             self.structure.ModuleType, self.structure.ModuleSubType,
-            purple(self.structure.PartitionName.decode("utf-8"))))
+            purple(utf8_decode_safe(self.structure.PartitionName))))
         for module in self.modules:
             module.showinfo(ts="  %s" % ts)
         for module in self.variable_modules:
@@ -480,7 +480,7 @@ class MeManifestHeader(MeObject):
             module.dump(parent)
         if self.huffman_llut is not None:
             self.huffman_llut.dump(
-                os.path.join(parent, self.structure.PartitionName.decode("utf-8")))
+                os.path.join(parent, utf8_decode_safe(self.structure.PartitionName)))
 
 
 class CPDEntry(MeObject):
@@ -622,17 +622,17 @@ class PartitionEntry(MeObject):
     def showinfo(self, ts='', index=None):
         print("%s%s name= %s owner= %s offset= 0x%x size= 0x%x (%d bytes) flags= 0x%x" % (
             ts, blue("ME Partition Entry"),
-            purple(self.structure.Name.decode("utf-8")), purple(self.structure.Owner),
+            purple(utf8_decode_safe(self.structure.Name)), purple(self.structure.Owner),
             self.structure.Offset, self.structure.Size, self.structure.Size, self.structure.Flags))
         if self.manifest is not None:
             self.manifest.showinfo("%s  " % ts)
 
     def dump(self, parent=""):
         if self.has_content:
-            dump_data(os.path.join(parent, "%s.partition" % self.structure.Name.decode("utf-8")),
+            dump_data(os.path.join(parent, "%s.partition" % utf8_decode_safe(self.structure.Name)),
                 self.data)
         if self.manifest is not None:
-            self.manifest.dump(os.path.join(parent, self.structure.Name.decode("utf-8")))
+            self.manifest.dump(os.path.join(parent, utf8_decode_safe(self.structure.Name)))
 
 class MeContainer(MeObject):
 

--- a/uefi_firmware/utils.py
+++ b/uefi_firmware/utils.py
@@ -165,3 +165,18 @@ def flatten_firmware_objects(base_objects):
         if "objects" in _object and len(_object["objects"]) > 0:
             objects += flatten_firmware_objects(_object["objects"])
     return objects
+
+def utf8_decode_safe(byte_array):
+    '''Safely decode a byte array into a UTF-8 string.
+
+    Args:
+        byte_array (bytes): Unsafe (presumably) UTF-8 encoded string
+
+    Returns:
+        str: A proper string OR a 0x-prefixed hex representation of input byte array
+    '''
+
+    try:
+        return byte_array.decode("utf-8")
+    except UnicodeDecodeError:
+        return "0x[{}]".format(byte_array.hex())


### PR DESCRIPTION
Disclaimer: I'm not sure if this tool is actually parsing this ME region correctly, but looking at the hex dump everything seems correct. It's just that the first partition entry name doesn't seem to be a valid string.

I was making a full dump of [this firmware (v3703)](https://www.asus.com/supportonly/p8p67-m/helpdesk_bios/) and the tool has crashed while dumping the ME region. This PR seems to fix the issue.

It follows the pattern established in #117 and #118 by @jstucke, I stumbled upon his code randomly while looking for examples of exception handling in similar cases. If @jstucke wants, I can mark his authorship of this snippet, I'm just not sure what would be the best way.