### PR TITLE
Fix uefi parse of ASUS UEFI CAP files

### DIFF
--- a/uefi_firmware/utils.py
+++ b/uefi_firmware/utils.py
@@ -102,6 +102,9 @@ def a2sguid(a):
 
 def aguid(b, big=False):
     '''RFC4122 binary GUID as int array.'''
+    if len(b) < 16:
+        for i in range(16 - len(b)):
+            b += b'\0'
     a, b, c, d = struct.unpack("%sIHH8s" % (">" if big else "<"), b)
     return [a, b, c] + [_c for _c in d]
 


### PR DESCRIPTION
Checked with: https://dlcdnets.asus.com/pub/ASUS/mb/BIOS/Pro-WS-WRX90E-SAGE-SE-ASUS-0502.zip

Workaround for:
```
  File "uefi_firmware/guids/__init__.py", line 21, in get_guid_name
    raw_guid = aguid(guid)
               ^^^^^^^^^^^
  File "/home/denis/Develop/linux-kernel/checks/uefi-firmware-parser/uefi_firmware/utils.py", line 105, in aguid
    a, b, c, d = struct.unpack("%sIHH8s" % (">" if big else "<"), b)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: unpack requires a buffer of 16 bytes
```