### PR TITLE
Fix Parsing of EFI_COMMON_SECTION_HEADER2

### DIFF
--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -763,12 +763,14 @@ class FirmwareFileSystemSection(EfiSection):
         header = data[:0x4]
 
         self.valid_header = True
+        large_header = False
         try:
             self.size, self.type = struct.unpack("<3sB", header)
             self.size = struct.unpack("<I", self.size + b"\x00")[0]
 
             # check if ExtendedSize is used (FFSv3 only)
             if self.size == 0xffffff:
+                large_header = True
                 self.size = struct.unpack("<I", data[4:8])[0]
 
         except Exception:
@@ -779,7 +781,10 @@ class FirmwareFileSystemSection(EfiSection):
             return
 
         self._data = data[:self.size]
-        self.data = data[0x4:self.size]
+        if large_header:
+            self.data = data[0x8:self.size]
+        else:
+            self.data = data[0x4:self.size]
         self.name = None
 
     @property


### PR DESCRIPTION
An issue has been observed in the case of an FFS section header using the EFI_COMMON_SECTION_HEADER2 header type. If this header type is used, the self.data attribute will erroneously contain the ExtendedSize field of the header at offset 0 instead of the beginning of the section data.

All header data should be stripped from self.data.

This issue has been corrected by offsetting the data by 8 bytes instead of 4 bytes when EFI_COMMON_SECTION_HEADER2 is found.