### PR TITLE
Fix to_dict() to handle FVs without a FV Name

### DIFF
--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -1516,9 +1516,13 @@ class FirmwareVolume(FirmwareObject):
 
         # TODO? for raw in self.raw_objects:
 
+        fvname = None
+        if hasattr(self, 'fvname'):
+            fvname = sguid(self.fvname)
+
         return {
             'guid': sguid(self.guid),
-            'nameGuid': sguid(self.fvname),
+            'nameGuid': fvname,
             'attributes': self.attributes,
             'revision': self.revision,
             'checksum': self.checksum,


### PR DESCRIPTION
If an FV does not contain the optional EFI_FIRMWARE_VOLUME_EXT_HEADER, then the to_dict() function will crash. The crash occurs when attempting to access the fvname attribute, because the fvname attribute does not exist in this case.

The fix is to check if the fvname attribute does not exist. If it does not, set nameGuid to None.