### PR TITLE
Improve showinfo() output for Version FFS

### DIFF
--- a/uefi_firmware/structs/uefi_structs.py
+++ b/uefi_firmware/structs/uefi_structs.py
@@ -73,7 +73,7 @@ EFI_SECTION_TYPES = {
     0x12: ("Terse executable (TE)",     "te",           "TE"),
     0x13: ("DXE dependency expression", "dxe.depex",    "DXE_DEPEX"),
     # Added from previous code (not in Phoenix spec
-    0x14: ("Version section",           "version",      "VERSION"),
+    0x14: ("Version",                   "version",      "VERSION"),
     0x15: ("User interface name",       "ui",           "UI"),
 
     0x16: ("IA-32 16-bit image",        "ia32.16bit",   "COMPAT16"),

--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -806,7 +806,8 @@ class FirmwareFileSystemSection(EfiSection):
             self.parsed_object = guid_defined
 
         elif self.type == 0x14:  # version string
-            self.name = uefi_name(self.data)
+            self.build_number = struct.unpack("<H", self.data[0:2])[0]
+            self.name = uefi_name(self.data[2:])
 
         elif self.type == 0x15:  # user interface name
             self.name = uefi_name(self.data)
@@ -887,7 +888,9 @@ class FirmwareFileSystemSection(EfiSection):
             _get_section_type(self.type)[0]
         ))
         if self.type == 0x15 and self.name is not None:
-            print ("%sName: %s" % (ts, purple(self.name)))
+            print ("%s  Name: %s" % (ts, purple(self.name)))
+        if self.type == 0x14 and self.name is not None:
+            print ("%s  Version: %s BuildNum: %d" % (ts, self.name, self.build_number))
         # DXE, PEI and SMM DEPEX sections
         if self.type == 0x13 or self.type == 0x1b or self.type == 0x1c:
             offset = 0


### PR DESCRIPTION
 - Output the version string and build number contained in the Version Firmware File Section (FFS)

 - Prevent the showinfo() output from containing "(Version section section)"" Because that is redundant.