### PR TITLE
MultiObject.to_dict() should return all FVs

### DIFF
--- a/uefi_firmware/__init__.py
+++ b/uefi_firmware/__init__.py
@@ -127,11 +127,17 @@ class MultiObject(FirmwareObject):
             self.objs[i].showinfo(ts, i)
 
     def to_dict(self):
-        volumes = []
-        for i in range(len(self.objs)):
-            obj = self.objs[i]
-            if type(obj) is uefi.FirmwareVolume:
-                volumes.append(obj.to_dict())
+        def get_fvs(multi_object):
+            volumes = []
+            for i in range(len(multi_object.objs)):
+                obj = multi_object.objs[i]
+                if type(obj) is uefi.FirmwareVolume:
+                    volumes.append(obj.to_dict())
+                if type(obj) is MultiObject:
+                    volumes.extend(get_fvs(obj))
+            return volumes
+        volumes = get_fvs(self)
+
         return { 'regions': [
             {
                 'type': 'bios',


### PR DESCRIPTION
Right now, MultiObject.to_dict() only returns FVs contained in the root MultiObject. It does not check if the MultiObject contains nested MultiObject instances that then contain Firmware Volumes. The fix is to make to_dict() perform a depth-first search through the tree of MultiObject instances and collect all FirmwareVolume objects in the tree.