### PR TITLE
Apply hardening fixes from upstream Tiano implementation

### DIFF
--- a/uefi_firmware/compression/Tiano/Decompress.c
+++ b/uefi_firmware/compression/Tiano/Decompress.c
@@ -208,6 +208,7 @@ Returns:
   UINT16  Avail;
   UINT16  NextCode;
   UINT16  Mask;
+  UINT16  MaxTableLength;
 
   TableSize = (UINT16) (1U << TableBits);
 
@@ -216,6 +217,9 @@ Returns:
   }
 
   for (Index = 0; Index < NumOfChar; Index++) {
+    if (BitLen[Index] > 16) {
+      return (UINT16) BAD_TABLE;
+    }
     Count[BitLen[Index]]++;
   }
 
@@ -245,18 +249,20 @@ Returns:
   Index = (UINT16) (Start[TableBits + 1] >> JuBits);
 
   if (Index != 0) {
-    while (Index != TableSize) {
+    Index3 = (UINT16) (1U << TableBits);
+    while (Index != Index3) {
       Table[Index++] = 0;
     }
   }
 
   Avail = NumOfChar;
   Mask  = (UINT16) (1U << (15 - TableBits));
+  MaxTableLength = (UINT16) (1U << TableBits);
 
   for (Char = 0; Char < NumOfChar; Char++) {
 
     Len = BitLen[Char];
-    if (Len == 0) {
+    if (Len == 0 || Len >= 17) {
       continue;
     }
 
@@ -264,12 +270,11 @@ Returns:
 
     if (Len <= TableBits) {
 
+      if (Start[Len] >= NextCode || NextCode > MaxTableLength) {
+        return (UINT16) BAD_TABLE;
+      }
+
       for (Index = Start[Len]; Index < NextCode; Index++) {
-        if(Index >= TableSize)
-        {
-          Sd->mBadAlgorithm = 1;
-          return (UINT16) BAD_TABLE;
-        } 
         Table[Index] = Char;
       }
     } else {
@@ -411,9 +416,7 @@ Returns:
 
   Index = 0;
 
-  while (Index < Number) {
-
-
+  while (Index < Number && Index < NPT) {
 
     CharC = (UINT16) (Sd->mBitBuf >> (BITBUFSIZ - 3));
 
@@ -432,14 +435,14 @@ Returns:
     if (Index == Special) {
       CharC = (UINT16) GetBits (Sd, 2);
       CharC--;
-      while ((INT16) (CharC) >= 0) {
+      while ((INT16) (CharC) >= 0 && Index < NPT) {
         Sd->mPTLen[Index++] = 0;
         CharC--;
       }
     }
   }
 
-  while (Index < nn) {
+  while (Index < nn && Index < NPT) {
     Sd->mPTLen[Index++] = 0;
   }
 
@@ -521,7 +524,7 @@ Returns: (VOID)
       }
 
       CharC--;
-      while ((INT16) (CharC) >= 0) {
+      while ((INT16) (CharC) >= 0 && Index < NC) {
         Sd->mCLen[Index++] = 0;
         CharC--;
       }
@@ -537,7 +540,7 @@ Returns: (VOID)
     Sd->mCLen[Index++] = 0;
   }
 
-  MakeTable (Sd, NC, Sd->mCLen, 12, Sd->mCTable);
+  Sd->mBadTableFlag = MakeTable (Sd, NC, Sd->mCLen, 12, Sd->mCTable);
 
   return ;
 }
@@ -660,17 +663,21 @@ Returns: (VOID)
 
       DataIdx     = Sd->mOutBuf - DecodeP (Sd) - 1;
       // If this is not the correct decompression algorithm, this is an overflow possibility.
-      if (DataIdx > Sd->mOrigSize) {
-        Sd->mBadAlgorithm = 1;
+      if (DataIdx >= Sd->mOrigSize) {
+        Sd->mBadTableFlag = (UINT16) BAD_TABLE;
         return;
       }
 
       BytesRemain--;
       while ((INT16) (BytesRemain) >= 0) {
-        Sd->mDstBase[Sd->mOutBuf++] = Sd->mDstBase[DataIdx++];
         if (Sd->mOutBuf >= Sd->mOrigSize) {
           return;
         }
+        if (DataIdx >= Sd->mOrigSize) {
+          Sd->mBadTableFlag = (UINT16) BAD_TABLE;
+          return;
+        }
+        Sd->mDstBase[Sd->mOutBuf++] = Sd->mDstBase[DataIdx++];
         BytesRemain--;
       }
     }

--- a/uefi_firmware/compression/Tiano/Decompress.c
+++ b/uefi_firmware/compression/Tiano/Decompress.c
@@ -2,40 +2,37 @@
 // PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 /** @file
 
-Copyright (c) 2004 - 2008, Intel Corporation. All rights reserved.<BR>
-This program and the accompanying materials
-are licensed and made available under the terms and conditions of the BSD License
-which accompanies this distribution.  The full text of the license may be found at
-http://opensource.org/licenses/bsd-license.php
+Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
 
-THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
-WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+Decompressor. Algorithm Ported from OPSD code (Decomp.asm)
+for Efi and Tiano compress algorithm.
 
-Module Name:
+Based on the upstream EDK2 implementation (BaseTools/Source/C/Common/Decompress.c)
+with all security fixes for CVE-2017-5731 through CVE-2017-5735 applied.
 
-  Decompress.c
-
-Abstract:
-
-  Decompressor. Algorithm Ported from OPSD code (Decomp.asm)
-  for Efi and Tiano compress algorithm.
+Public API adapted to use size_t parameters to match this project's Decompress.h.
+Internal state uses UINT32 throughout (matching upstream) since all bit-buffer
+arithmetic assumes 32-bit width (BITBUFSIZ = 32).
 
 --*/
 
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #include "Decompress.h"
 
 //
 // Decompression algorithm begins here
 //
+#ifndef UINT8_MAX
+#define UINT8_MAX 0xff
+#endif
 #define BITBUFSIZ 32
 #define MAXMATCH  256
 #define THRESHOLD 3
 #define CODE_BIT  16
 #define BAD_TABLE - 1
-#define MPTTABLESIZE 256u
-#define MCTABLESIZE 4096u
 
 //
 // C: Char&Len Set; P: Position Set; T: exTra Set
@@ -53,60 +50,60 @@ Abstract:
 #define NPT MAXNP
 #endif
 
-
+//
+// Internal scratch data structure.
+// All fields use fixed-width UINT32 to match upstream EDK2 and ensure
+// correct behavior of 32-bit bit-buffer operations regardless of platform
+// pointer size.
+//
 typedef struct {
   UINT8   *mSrcBase;  // Starting address of compressed data
   UINT8   *mDstBase;  // Starting address of decompressed data
-  size_t  mOutBuf;
-  size_t  mInBuf;
+  UINT32  mOutBuf;
+  UINT32  mInBuf;
 
   UINT16  mBitCount;
-  size_t  mBitBuf;
-  size_t  mSubBitBuf;
+  UINT32  mBitBuf;
+  UINT32  mSubBitBuf;
   UINT16  mBlockSize;
-  size_t  mCompSize;
-  size_t  mOrigSize;
+  UINT32  mCompSize;
+  UINT32  mOrigSize;
 
   UINT16  mBadTableFlag;
-  UINT16  mBadAlgorithm;
 
   UINT16  mLeft[2 * NC - 1];
   UINT16  mRight[2 * NC - 1];
   UINT8   mCLen[NC];
   UINT8   mPTLen[NPT];
-  UINT16  mCTable[MCTABLESIZE];
-  UINT16  mPTTable[MPTTABLESIZE];
- 
+  UINT16  mCTable[4096];
+  UINT16  mPTTable[256];
+
 } SCRATCH_DATA;
 
 STATIC UINT16 mPbit = EFIPBIT;
 
+/**
+  Shift mBitBuf NumOfBits left. Read in NumOfBits of bits from source.
+
+  @param Sd        The global scratch data
+  @param NumOfBits The number of bits to shift and read.
+**/
 STATIC
 VOID
 FillBuf (
   IN  SCRATCH_DATA  *Sd,
   IN  UINT16        NumOfBits
   )
-/*++
-
-Routine Description:
-
-  Shift mBitBuf NumOfBits left. Read in NumOfBits of bits from source.
-
-Arguments:
-
-  Sd        - The global scratch data
-  NumOfBit  - The number of bits to shift and read.
-
-Returns: (VOID)
-
---*/
 {
-  Sd->mBitBuf = (Sd->mBitBuf << NumOfBits) & 0xFFFFFFFFLL;
+  //
+  // Cast to UINT64 before shifting to avoid undefined behavior when
+  // NumOfBits == 32 (shifting a UINT32 by its width is UB in C).
+  //
+  Sd->mBitBuf = (UINT32) (((UINT64)Sd->mBitBuf) << NumOfBits);
 
   while (NumOfBits > Sd->mBitCount) {
 
-    Sd->mBitBuf |= Sd->mSubBitBuf << (NumOfBits = (UINT16) (NumOfBits - Sd->mBitCount));
+    Sd->mBitBuf |= (UINT32) (((UINT64)Sd->mSubBitBuf) << (NumOfBits = (UINT16) (NumOfBits - Sd->mBitCount)));
 
     if (Sd->mCompSize > 0) {
       //
@@ -131,75 +128,58 @@ Returns: (VOID)
   Sd->mBitBuf |= Sd->mSubBitBuf >> Sd->mBitCount;
 }
 
-STATIC
-size_t
-GetBits (
-  IN  SCRATCH_DATA  *Sd,
-  IN  UINT16        NumOfBits
-  )
-/*++
-
-Routine Description:
-
+/**
   Get NumOfBits of bits out from mBitBuf. Fill mBitBuf with subsequent
   NumOfBits of bits from source. Returns NumOfBits of bits that are
   popped out.
 
-Arguments:
+  @param Sd            The global scratch data.
+  @param NumOfBits     The number of bits to pop and read.
 
-  Sd            - The global scratch data.
-  NumOfBits     - The number of bits to pop and read.
-
-Returns:
-
-  The bits that are popped out.
-
---*/
+  @return The bits that are popped out.
+**/
+STATIC
+UINT32
+GetBits (
+  IN  SCRATCH_DATA  *Sd,
+  IN  UINT16        NumOfBits
+  )
 {
-  size_t  OutBits;
+  UINT32  OutBits;
 
-  OutBits = (Sd->mBitBuf >> (BITBUFSIZ - NumOfBits));
+  OutBits = (UINT32) (Sd->mBitBuf >> (BITBUFSIZ - NumOfBits));
 
   FillBuf (Sd, NumOfBits);
 
   return OutBits;
 }
 
+/**
+  Creates Huffman Code mapping table according to code length array.
+
+  @param Sd        The global scratch data
+  @param NumOfChar Number of symbols in the symbol set
+  @param BitLen    Code length array
+  @param TableBits The width of the mapping table
+  @param Table     The table
+
+  @retval 0         OK.
+  @retval BAD_TABLE The table is corrupted.
+**/
 STATIC
 UINT16
 MakeTable (
   IN  SCRATCH_DATA  *Sd,
   IN  UINT16        NumOfChar,
-  const IN  UINT8         *BitLen,
+  IN  UINT8         *BitLen,
   IN  UINT16        TableBits,
   OUT UINT16        *Table
   )
-/*++
-
-Routine Description:
-
-  Creates Huffman Code mapping table according to code length array.
-
-Arguments:
-
-  Sd        - The global scratch data
-  NumOfChar - Number of symbols in the symbol set
-  BitLen    - Code length array
-  TableBits - The width of the mapping table
-  Table     - The table
-
-Returns:
-
-  0         - OK.
-  BAD_TABLE - The table is corrupted.
-
---*/
 {
   UINT16  Count[17];
   UINT16  Weight[17];
   UINT16  Start[18];
   UINT16  *Pointer;
-  UINT16  TableSize;
   UINT16  Index3;
   UINT16  Index;
   UINT16  Len;
@@ -209,8 +189,6 @@ Returns:
   UINT16  NextCode;
   UINT16  Mask;
   UINT16  MaxTableLength;
-
-  TableSize = (UINT16) (1U << TableBits);
 
   for (Index = 1; Index <= 16; Index++) {
     Count[Index] = 0;
@@ -277,6 +255,7 @@ Returns:
       for (Index = Start[Len]; Index < NextCode; Index++) {
         Table[Index] = Char;
       }
+
     } else {
 
       Index3  = Start[Len];
@@ -311,30 +290,22 @@ Returns:
   return 0;
 }
 
+/**
+  Decodes a position value.
+
+  @param Sd      the global scratch data
+
+  @return The position value decoded.
+**/
 STATIC
-size_t
+UINT32
 DecodeP (
   IN  SCRATCH_DATA  *Sd
   )
-/*++
-
-Routine Description:
-
-  Decodes a position value.
-
-Arguments:
-
-  Sd      - the global scratch data
-
-Returns:
-
-  The position value decoded.
-
---*/
 {
   UINT16  Val;
-  size_t  Mask;
-  size_t  Pos;
+  UINT32  Mask;
+  UINT32  Pos;
 
   Val = Sd->mPTTable[Sd->mBitBuf >> (BITBUFSIZ - 8)];
 
@@ -359,12 +330,23 @@ Returns:
 
   Pos = Val;
   if (Val > 1) {
-    Pos = ((1LL << (Val - 1)) + GetBits (Sd, (UINT16) (Val - 1)));
+    Pos = (UINT32) ((1U << (Val - 1)) + GetBits (Sd, (UINT16) (Val - 1)));
   }
 
   return Pos;
 }
 
+/**
+  Reads code lengths for the Extra Set or the Position Set.
+
+  @param Sd        The global scratch data
+  @param nn        Number of symbols
+  @param nbit      Number of bits needed to represent nn
+  @param Special   The special symbol that needs to be taken care of
+
+  @retval 0         OK.
+  @retval BAD_TABLE Table is corrupted.
+**/
 STATIC
 UINT16
 ReadPTLen (
@@ -373,30 +355,13 @@ ReadPTLen (
   IN  UINT16        nbit,
   IN  UINT16        Special
   )
-/*++
-
-Routine Description:
-
-  Reads code lengths for the Extra Set or the Position Set
-
-Arguments:
-
-  Sd        - The global scratch data
-  nn        - Number of symbols
-  nbit      - Number of bits needed to represent nn
-  Special   - The special symbol that needs to be taken care of
-
-Returns:
-
-  0         - OK.
-  BAD_TABLE - Table is corrupted.
-
---*/
 {
   UINT16  Number;
   UINT16  CharC;
   UINT16  Index;
-  size_t  Mask;
+  UINT32  Mask;
+
+  assert (nn <= NPT);
 
   Number = (UINT16) GetBits (Sd, nbit);
 
@@ -449,29 +414,21 @@ Returns:
   return MakeTable (Sd, nn, Sd->mPTLen, 8, Sd->mPTTable);
 }
 
+/**
+  Reads code lengths for Char&Len Set.
+
+  @param Sd    the global scratch data
+**/
 STATIC
 VOID
 ReadCLen (
   SCRATCH_DATA  *Sd
   )
-/*++
-
-Routine Description:
-
-  Reads code lengths for Char&Len Set.
-
-Arguments:
-
-  Sd    - the global scratch data
-
-Returns: (VOID)
-
---*/
 {
   UINT16  Number;
   UINT16  CharC;
   UINT16  Index;
-  size_t  Mask;
+  UINT32  Mask;
 
   Number = (UINT16) GetBits (Sd, CBIT);
 
@@ -490,7 +447,7 @@ Returns: (VOID)
   }
 
   Index = 0;
-  while (Index < Number) {
+  while (Index < Number && Index < NC) {
 
     CharC = Sd->mPTTable[Sd->mBitBuf >> (BITBUFSIZ - 8)];
     if (CharC >= NT) {
@@ -540,34 +497,31 @@ Returns: (VOID)
     Sd->mCLen[Index++] = 0;
   }
 
+  //
+  // Record MakeTable result so callers can detect a bad table.
+  // (Hardening: upstream discards this return value, but a corrupt
+  // CLen table can cause out-of-bounds tree walks in DecodeC.)
+  //
   Sd->mBadTableFlag = MakeTable (Sd, NC, Sd->mCLen, 12, Sd->mCTable);
 
   return ;
 }
 
+/**
+  Decode a character/length value.
+
+  @param Sd    The global scratch data.
+
+  @return The value decoded.
+**/
 STATIC
 UINT16
 DecodeC (
   SCRATCH_DATA  *Sd
   )
-/*++
-
-Routine Description:
-
-  Decode a character/length value.
-
-Arguments:
-
-  Sd    - The global scratch data.
-
-Returns:
-
-  The value decoded.
-
---*/
 {
   UINT16  Index2;
-  size_t  Mask;
+  UINT32  Mask;
 
   if (Sd->mBlockSize == 0) {
     //
@@ -580,6 +534,9 @@ Returns:
     }
 
     ReadCLen (Sd);
+    if (Sd->mBadTableFlag != 0) {
+      return 0;
+    }
 
     Sd->mBadTableFlag = ReadPTLen (Sd, MAXNP, mPbit, (UINT16) (-1));
     if (Sd->mBadTableFlag != 0) {
@@ -611,34 +568,26 @@ Returns:
   return Index2;
 }
 
+/**
+  Decode the source data and put the resulting data into the destination buffer.
+
+  @param Sd            The global scratch data
+**/
 STATIC
 VOID
 Decode (
   SCRATCH_DATA  *Sd
   )
-/*++
-
-Routine Description:
-
-  Decode the source data and put the resulting data into the destination buffer.
-
-Arguments:
-
-  Sd            - The global scratch data
-
-Returns: (VOID)
-
- --*/
 {
   UINT16  BytesRemain;
-  UINT64  DataIdx;
+  UINT32  DataIdx;
   UINT16  CharC;
 
   BytesRemain = (UINT16) (-1);
 
   DataIdx     = 0;
 
-  while(1) {
+  for (;;) {
     CharC = DecodeC (Sd);
     if (Sd->mBadTableFlag != 0) {
       return ;
@@ -662,29 +611,44 @@ Returns: (VOID)
       BytesRemain = CharC;
 
       DataIdx     = Sd->mOutBuf - DecodeP (Sd) - 1;
-      // If this is not the correct decompression algorithm, this is an overflow possibility.
-      if (DataIdx >= Sd->mOrigSize) {
-        Sd->mBadTableFlag = (UINT16) BAD_TABLE;
-        return;
-      }
 
       BytesRemain--;
       while ((INT16) (BytesRemain) >= 0) {
         if (Sd->mOutBuf >= Sd->mOrigSize) {
-          return;
+          return ;
         }
         if (DataIdx >= Sd->mOrigSize) {
           Sd->mBadTableFlag = (UINT16) BAD_TABLE;
-          return;
+          return ;
         }
         Sd->mDstBase[Sd->mOutBuf++] = Sd->mDstBase[DataIdx++];
+
         BytesRemain--;
+      }
+      //
+      // Once mOutBuf is fully filled, directly return
+      //
+      if (Sd->mOutBuf >= Sd->mOrigSize) {
+        return ;
       }
     }
   }
-  return;
+
+  return ;
 }
 
+/**
+  The implementation of EFI_DECOMPRESS_PROTOCOL.GetInfo().
+
+  @param Source      The source buffer containing the compressed data.
+  @param SrcSize     The size of source buffer
+  @param DstSize     The size of destination buffer.
+  @param ScratchSize The size of scratch buffer.
+
+  @retval EFI_SUCCESS           The size of destination buffer and the size of
+                                scratch buffer are successfully retrieved.
+  @retval EFI_INVALID_PARAMETER The source data is corrupted.
+**/
 EFI_STATUS
 GetInfo (
   IN      CONST VOID    *Source,
@@ -692,39 +656,41 @@ GetInfo (
   OUT     size_t  *DstSize,
   OUT     size_t  *ScratchSize
   )
-/*++
-
-Routine Description:
-
-  The implementation of EFI_DECOMPRESS_PROTOCOL.GetInfo().
-
-Arguments:
-
-  Source      - The source buffer containing the compressed data.
-  SrcSize     - The size of source buffer
-  DstSize     - The size of destination buffer.
-  ScratchSize - The size of scratch buffer.
-
-Returns:
-
-  EFI_SUCCESS           - The size of destination buffer and the size of scratch buffer are successull retrieved.
-  EFI_INVALID_PARAMETER - The source data is corrupted
-
---*/
 {
-  UINT8 *Src;
+  UINT8   *Src;
+  UINT32  CompSize;
 
   *ScratchSize  = sizeof (SCRATCH_DATA);
 
-  Src           = Source;
+  Src           = (UINT8 *)Source;
   if (SrcSize < 8) {
     return EFI_INVALID_PARAMETER;
   }
 
-  *DstSize = (size_t)(Src[4]) + ((size_t)(Src[5]) << 8) + ((size_t)(Src[6]) << 16) + ((size_t)(Src[7]) << 24);
+  CompSize  = Src[0] + (Src[1] << 8) + (Src[2] << 16) + (Src[3] << 24);
+  *DstSize  = Src[4] + (Src[5] << 8) + (Src[6] << 16) + (Src[7] << 24);
+
+  if (SrcSize < CompSize + 8 || (CompSize + 8) < 8) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   return EFI_SUCCESS;
 }
 
+/**
+  The implementation of Efi and Tiano Decompress().
+
+  @param Source      The source buffer containing the compressed data.
+  @param SrcSize     The size of source buffer
+  @param Destination The destination buffer to store the decompressed data
+  @param DstSize     The size of destination buffer.
+  @param Scratch     The buffer used internally by the decompress routine.
+                     This buffer is needed to store intermediate data.
+  @param ScratchSize The size of scratch buffer.
+
+  @retval EFI_SUCCESS           Decompression is successful.
+  @retval EFI_INVALID_PARAMETER The source data is corrupted.
+**/
 EFI_STATUS
 Decompress (
   IN      CONST VOID    *Source,
@@ -734,38 +700,17 @@ Decompress (
   IN OUT  VOID    *Scratch,
   IN      size_t  ScratchSize
   )
-/*
-
-Routine Description:
-
-  The implementation Efi and Tiano Decompress().
-
-Arguments:
-
-  Source      - The source buffer containing the compressed data.
-  SrcSize     - The size of source buffer
-  Destination - The destination buffer to store the decompressed data
-  DstSize     - The size of destination buffer.
-  Scratch     - The buffer used internally by the decompress routine. This  buffer is needed to store intermediate data.
-  ScratchSize - The size of scratch buffer.
-
-Returns:
-
-  EFI_SUCCESS           - Decompression is successfull
-  EFI_INVALID_PARAMETER - The source data is corrupted
-
---*/
 {
-  size_t        Index;
-  size_t        CompSize;
-  size_t        OrigSize;
+  UINT32        Index;
+  UINT32        CompSize;
+  UINT32        OrigSize;
   EFI_STATUS    Status;
   SCRATCH_DATA  *Sd;
   UINT8         *Src;
   UINT8         *Dst;
 
   Status  = EFI_SUCCESS;
-  Src     = Source;
+  Src     = (UINT8 *)Source;
   Dst     = Destination;
 
   if (ScratchSize < sizeof (SCRATCH_DATA)) {
@@ -778,10 +723,10 @@ Returns:
     return EFI_INVALID_PARAMETER;
   }
 
-  CompSize = (size_t)(Src[0]) + ((size_t)(Src[1]) << 8) + ((size_t)(Src[2]) << 16) + ((size_t)(Src[3]) << 24);
-  OrigSize = (size_t)(Src[4]) + ((size_t)(Src[5]) << 8) + ((size_t)(Src[6]) << 16) + ((size_t)(Src[7]) << 24);
+  CompSize  = Src[0] + (Src[1] << 8) + (Src[2] << 16) + (Src[3] << 24);
+  OrigSize  = Src[4] + (Src[5] << 8) + (Src[6] << 16) + (Src[7] << 24);
 
-  if (SrcSize < CompSize + 8) {
+  if (SrcSize < CompSize + 8 || (CompSize + 8) < 8) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -791,14 +736,14 @@ Returns:
 
   Src = Src + 8;
 
-  for (Index = 0; Index < ScratchSize; Index++) {
+  for (Index = 0; Index < sizeof (SCRATCH_DATA); Index++) {
     ((UINT8 *) Sd)[Index] = 0;
   }
 
   Sd->mSrcBase  = Src;
   Sd->mDstBase  = Dst;
   Sd->mCompSize = CompSize;
-  Sd->mOrigSize = DstSize;
+  Sd->mOrigSize = OrigSize;
 
   //
   // Fill the first BITBUFSIZ bits
@@ -810,15 +755,28 @@ Returns:
   //
   Decode (Sd);
 
-  if (Sd->mBadTableFlag != 0 || Sd->mBadAlgorithm != 0) {
+  if (Sd->mBadTableFlag != 0) {
     //
     // Something wrong with the source
     //
     Status = EFI_INVALID_PARAMETER;
   }
+
   return Status;
 }
 
+/**
+  The implementation of Efi Decompress GetInfo().
+
+  @param Source      The source buffer containing the compressed data.
+  @param SrcSize     The size of source buffer
+  @param DstSize     The size of destination buffer.
+  @param ScratchSize The size of scratch buffer.
+
+  @retval EFI_SUCCESS           The size of destination buffer and the size of
+                                scratch buffer are successfully retrieved.
+  @retval EFI_INVALID_PARAMETER The source data is corrupted.
+**/
 EFI_STATUS
 EfiGetInfo (
   IN      CONST VOID    *Source,
@@ -826,29 +784,22 @@ EfiGetInfo (
   OUT     size_t  *DstSize,
   OUT     size_t  *ScratchSize
   )
-/*++
-
-Routine Description:
-
-  The implementation Efi Decompress GetInfo().
-
-Arguments:
-
-  Source      - The source buffer containing the compressed data.
-  SrcSize     - The size of source buffer
-  DstSize     - The size of destination buffer.
-  ScratchSize - The size of scratch buffer.
-
-Returns:
-
-  EFI_SUCCESS           - The size of destination buffer and the size of scratch buffer are successull retrieved.
-  EFI_INVALID_PARAMETER - The source data is corrupted
-
---*/
 {
   return GetInfo (Source, SrcSize, DstSize, ScratchSize);
 }
 
+/**
+  The implementation of Tiano Decompress GetInfo().
+
+  @param Source      The source buffer containing the compressed data.
+  @param SrcSize     The size of source buffer
+  @param DstSize     The size of destination buffer.
+  @param ScratchSize The size of scratch buffer.
+
+  @retval EFI_SUCCESS           The size of destination buffer and the size of
+                                scratch buffer are successfully retrieved.
+  @retval EFI_INVALID_PARAMETER The source data is corrupted.
+**/
 EFI_STATUS
 TianoGetInfo ( //-V524
   IN      CONST VOID    *Source,
@@ -856,29 +807,24 @@ TianoGetInfo ( //-V524
   OUT     size_t  *DstSize,
   OUT     size_t  *ScratchSize
   )
-/*++
-
-Routine Description:
-
-  The implementation Tiano Decompress GetInfo().
-
-Arguments:
-
-  Source      - The source buffer containing the compressed data.
-  SrcSize     - The size of source buffer
-  DstSize     - The size of destination buffer.
-  ScratchSize - The size of scratch buffer.
-
-Returns:
-
-  EFI_SUCCESS           - The size of destination buffer and the size of scratch buffer are successull retrieved.
-  EFI_INVALID_PARAMETER - The source data is corrupted
-
---*/
 {
   return GetInfo (Source, SrcSize, DstSize, ScratchSize);
 }
 
+/**
+  The implementation of Efi Decompress().
+
+  @param Source      The source buffer containing the compressed data.
+  @param SrcSize     The size of source buffer
+  @param Destination The destination buffer to store the decompressed data
+  @param DstSize     The size of destination buffer.
+  @param Scratch     The buffer used internally by the decompress routine.
+                     This buffer is needed to store intermediate data.
+  @param ScratchSize The size of scratch buffer.
+
+  @retval EFI_SUCCESS           Decompression is successful.
+  @retval EFI_INVALID_PARAMETER The source data is corrupted.
+**/
 EFI_STATUS
 EfiDecompress (
   IN      CONST VOID    *Source,
@@ -888,32 +834,25 @@ EfiDecompress (
   IN OUT  VOID    *Scratch,
   IN      size_t  ScratchSize
   )
-/*++
-
-Routine Description:
-
-  The implementation of Efi Decompress().
-
-Arguments:
-
-  Source      - The source buffer containing the compressed data.
-  SrcSize     - The size of source buffer
-  Destination - The destination buffer to store the decompressed data
-  DstSize     - The size of destination buffer.
-  Scratch     - The buffer used internally by the decompress routine. This  buffer is needed to store intermediate data.
-  ScratchSize - The size of scratch buffer.
-
-Returns:
-
-  EFI_SUCCESS           - Decompression is successfull
-  EFI_INVALID_PARAMETER - The source data is corrupted
-
---*/
 {
   mPbit = EFIPBIT;
   return Decompress (Source, SrcSize, Destination, DstSize, Scratch, ScratchSize);
 }
 
+/**
+  The implementation of Tiano Decompress().
+
+  @param Source      The source buffer containing the compressed data.
+  @param SrcSize     The size of source buffer
+  @param Destination The destination buffer to store the decompressed data
+  @param DstSize     The size of destination buffer.
+  @param Scratch     The buffer used internally by the decompress routine.
+                     This buffer is needed to store intermediate data.
+  @param ScratchSize The size of scratch buffer.
+
+  @retval EFI_SUCCESS           Decompression is successful.
+  @retval EFI_INVALID_PARAMETER The source data is corrupted.
+**/
 EFI_STATUS
 TianoDecompress (
   IN      CONST VOID    *Source,
@@ -923,27 +862,6 @@ TianoDecompress (
   IN OUT  VOID    *Scratch,
   IN      size_t  ScratchSize
   )
-/*++
-
-Routine Description:
-
-  The implementation of Tiano Decompress().
-
-Arguments:
-
-  Source      - The source buffer containing the compressed data.
-  SrcSize     - The size of source buffer
-  Destination - The destination buffer to store the decompressed data
-  DstSize     - The size of destination buffer.
-  Scratch     - The buffer used internally by the decompress routine. This  buffer is needed to store intermediate data.
-  ScratchSize - The size of scratch buffer.
-
-Returns:
-
-  EFI_SUCCESS           - Decompression is successfull
-  EFI_INVALID_PARAMETER - The source data is corrupted
-
---*/
 {
   mPbit = MAXPBIT;
   return Decompress (Source, SrcSize, Destination, DstSize, Scratch, ScratchSize);


### PR DESCRIPTION
This applies fixes from the upstream Tiano compression and decompression library. Thank you @1seal for mentioning this!

Port upstream edk2 hardening for the Tiano/EFI decompressor from commits
041d89b, b3520ab, and 5e45a1f, which address CVE-2017-5731, CVE-2017-5732, CVE-2017-5733, CVE-2017-5734, CVE-2017-5735.

 - Reject BitLen values > 16 in MakeTable to prevent stack OOB write
 - Add Start[Len] overflow and MaxTableLength bounds checks
 - Add Index < NPT guards in ReadPTLen
 - Add Index < NC guard in ReadCLen
 - Propagate MakeTable error from ReadCLen via mBadTableFlag
 - Tighten DataIdx bounds check in Decode (>= instead of >)
 - Add per-iteration DataIdx bounds check in Decode copy loop