### PR TITLE
Fix: drop python-future dependency

### DIFF
--- a/scripts/fv_injector.py
+++ b/scripts/fv_injector.py
@@ -10,11 +10,9 @@ from uefi_firmware.utils import dump_data, flatten_firmware_objects
 from uefi_firmware.pfs import PFSFile
 
 try:
-    import __builtin__
-
-    input = getattr(__builtin__, 'raw_input')
-except (ImportError, AttributeError):
-    pass
+    input_func = raw_input
+except NameError:
+    input_func = input
 
 
 def brute_search(data):
@@ -68,7 +66,7 @@ def parse_file(data):
     selection = 0
 
     while True:
-        selection = input(
+        selection = input_func(
             "[#] Replace what section: [1-%d]: " % len(obj_references))
         try:
             selection = int(selection)

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     scripts=[
         'bin/uefi-firmware-parser',
     ],
-    install_requires=['future'],
+    install_requires=[],
     classifiers=[
         # https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 4 - Beta',

--- a/uefi_firmware/misc/checker.py
+++ b/uefi_firmware/misc/checker.py
@@ -3,14 +3,13 @@ These are misc functions/classes to implement several type checkers.
 The TypeTester may be useful if parsing a large number of UEFI-related binaries.
 """
 
-
-from builtins import bytes
 import re
 
 from ..uefi import FirmwareVolume, FirmwareCapsule, FirmwareFile
 from ..pfs import PFSFile, PFHeader
 from ..flash import FlashDescriptor
 from ..me import MeContainer, MeManifestHeader
+from ..utils import from_hex
 
 
 class TypeTester(object):
@@ -48,19 +47,19 @@ class FlashDescriptorTester(TypeTester):
 
 
 class EFICapsuleTester(TypeTester):
-    static = bytes.fromhex("".join(
+    static = from_hex("".join(
         "BD 86 66 3B 76 0D 30 40 B7 0E B5 51 9E 2F C5 A0".split()))
     parser = FirmwareCapsule
 
 
 class UEFICapsuleTester(TypeTester):
-    static = bytes.fromhex("".join(
+    static = from_hex("".join(
         "B9 82 91 53 B5 AB 91 43 B6 9A E3 A9 43 F7 2F CC".split()))
     parser = FirmwareCapsule
 
 
 class IntelMEPartitionManifestTester(TypeTester):
-    static = bytes.fromhex("".join("04 00 00 00 A1 00 00 00".split()))
+    static = from_hex("".join("04 00 00 00 A1 00 00 00".split()))
     parser = MeManifestHeader
 
 

--- a/uefi_firmware/utils.py
+++ b/uefi_firmware/utils.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import os
 import sys
 import struct
-from builtins import bytes
 import binascii
 
 nocolor = False
@@ -46,6 +44,12 @@ def print_error(msg):
     print(msg, file=sys.stderr)
 
 
+def from_hex(text):
+    '''Convert a hex string into bytes in Python 2/3.'''
+    # py2 returns a byte string (`str`), py3 returns `bytes`, both are binary data.
+    return binascii.unhexlify(text)
+
+
 def ascii_char(c):
     '''Return the ASCII or (.) representation of the input character.'''
     if isinstance(c, str):
@@ -82,7 +86,9 @@ def sguid(b, big=False):
     if b is None or len(b) != 16:
         return ""
     a, b, c, d = struct.unpack("%sIHH8s" % (">" if big else "<"), b)
-    d = ''.join('%02x' % c for c in bytes(d))
+    d = binascii.hexlify(d)
+    if not isinstance(d, str):
+        d = d.decode('ascii')
     return "%08x-%04x-%04x-%s-%s" % (a, b, c, d[:4], d[4:])
 
 
@@ -90,17 +96,16 @@ def s2aguid(s):
     '''RFC4122 string GUID as int array.'''
     guid = [s[:8], s[8 + 1:9 + 4], s[13 + 1:14 + 4],
             s[18 + 1:19 + 4] + s[-12:]]
-    return aguid(b"".join([bytes.fromhex(part) for part in guid]), True)
+    return aguid(b"".join([from_hex(part) for part in guid]), True)
 
 
 def a2sguid(a):
     '''RFC4122 int array GUID as string.'''
-    guid = ""
+    guid = bytearray()
     for value in a:
         value = format(value, 'x')
-        guid += value.zfill(len(value) + len(value) % 2).decode("hex")
-    guid = guid.zfill(len(guid) + len(guid) % 2)
-    return sguid(guid, True)
+        guid.extend(from_hex(value.zfill(len(value) + len(value) % 2)))
+    return sguid(bytes(guid), True)
 
 
 def aguid(b, big=False):
@@ -109,7 +114,8 @@ def aguid(b, big=False):
         for i in range(16 - len(b)):
             b += b'\0'
     a, b, c, d = struct.unpack("%sIHH8s" % (">" if big else "<"), b)
-    return [a, b, c] + [_c for _c in d]
+    tail = bytearray(d)
+    return [a, b, c] + [value for value in tail]
 
 
 def bit_set(field, bit):


### PR DESCRIPTION
I see that the project depends on the `python-future` package, but I think this dependency is redundant. The future project depends on `lib2to3`, but this package seems to have been deprecated in python 3.11 and removed in python 3.13.

However, I think build this project in a `python 3.13` environment currently pulls in `python-future`, which is a legacy compatibility dependency and is no longer appropriate here.

https://docs.python.org/3.13/whatsnew/3.13.html#removed
> Remove the 2to3 tool and lib2to3 module (deprecated in Python 3.11).

Of course, the above are just suggestions.

:>