### PR TITLE
Build generic stable ABI wheels targeting Python 3.10+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sysconfig
 
 from setuptools import Command, Extension, find_packages, setup
 
@@ -63,6 +64,18 @@ for root, directory, paths in os.walk("uefi_firmware/compression"):
         elif os.path.splitext(path)[1][1:] == "c":
             COMPRESSION_SOURCES.append(os.path.join(root, path))
 
+IS_FREE_THREADED = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
+
+if IS_FREE_THREADED:
+    options = {}
+else:
+    options = {
+        "bdist_wheel": {
+            "py_limited_api": "cp310",
+        }
+    }
+
+
 setup(
     name="uefi_firmware",
     version=VERSION,
@@ -87,11 +100,7 @@ setup(
         )
     ],
     python_requires=">=3.10",
-    options={
-        "bdist_wheel": {
-            "py_limited_api": "cp310",
-        }
-    },
+    options=options,
     scripts=[
         "bin/uefi-firmware-parser",
     ],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 
 import os
 import re
-from setuptools import setup, find_packages, Extension, Command
+
+from setuptools import Command, Extension, find_packages, setup
 
 
 class LintCommand(Command):
@@ -11,10 +12,7 @@ class LintCommand(Command):
     description = "Run pylint on implementation and test code"
     user_options = []
 
-    _pylint_options = [
-        "--max-line-length 80",
-        "--ignore-imports yes"
-    ]
+    _pylint_options = ["--max-line-length 80", "--ignore-imports yes"]
 
     _lint_paths = [
         "uefi_firmware/*.py",
@@ -34,41 +32,47 @@ class LintCommand(Command):
 
     def run(self):
         """Run the command"""
-        os.system("pylint %s %s" % (
-            " ".join(self._pylint_options),
-            " ".join(self._lint_paths),
-        ))
+        os.system(
+            "pylint %s %s"
+            % (
+                " ".join(self._pylint_options),
+                " ".join(self._lint_paths),
+            )
+        )
 
-with open('README.rst') as f:
+
+with open("README.rst") as f:
     README = f.read()
 
 with open("uefi_firmware/__init__.py", "r") as f:
     __INIT__ = f.read()
 
-VERSION = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                    __INIT__, re.MULTILINE).group(1)
-AUTHOR = re.search(r'^__author__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                   __INIT__, re.MULTILINE).group(1)
+VERSION = re.search(
+    r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', __INIT__, re.MULTILINE
+).group(1)
+AUTHOR = re.search(
+    r'^__author__\s*=\s*[\'"]([^\'"]*)[\'"]', __INIT__, re.MULTILINE
+).group(1)
 
 COMPRESSION_SOURCES = []
 COMPRESSION_HEADERS = []
-for root, directory, paths in os.walk('uefi_firmware/compression'):
+for root, directory, paths in os.walk("uefi_firmware/compression"):
     for path in paths:
-        if os.path.splitext(path)[1][1:] == 'h':
+        if os.path.splitext(path)[1][1:] == "h":
             COMPRESSION_HEADERS.append(os.path.join(root, path))
-        elif os.path.splitext(path)[1][1:] == 'c':
+        elif os.path.splitext(path)[1][1:] == "c":
             COMPRESSION_SOURCES.append(os.path.join(root, path))
 
 setup(
-    name='uefi_firmware',
+    name="uefi_firmware",
     version=VERSION,
-    description='Various data structures and parsing tools for UEFI firmware.',
+    description="Various data structures and parsing tools for UEFI firmware.",
     long_description=README,
     author=AUTHOR,
-    author_email='teddy@prosauce.org',
-    url='https://github.com/theopolis/uefi-firmware-parser',
-    license='BSD',
-    packages=find_packages(exclude=('tests', 'docs')),
+    author_email="teddy@prosauce.org",
+    url="https://github.com/theopolis/uefi-firmware-parser",
+    license="BSD",
+    packages=find_packages(exclude=("tests", "docs")),
     test_suite="tests",
     cmdclass={
         "lint": LintCommand,
@@ -76,25 +80,29 @@ setup(
     headers=COMPRESSION_HEADERS,
     ext_modules=[
         Extension(
-            'uefi_firmware.efi_compressor',
+            "uefi_firmware.efi_compressor",
             sources=COMPRESSION_SOURCES,
-            include_dirs=[
-                os.path.join("uefi_firmware", 'compression', 'Include')
-            ],
+            include_dirs=[os.path.join("uefi_firmware", "compression", "Include")],
             depends=COMPRESSION_HEADERS,
         )
     ],
+    python_requires=">=3.10",
+    options={
+        "bdist_wheel": {
+            "py_limited_api": "cp310",
+        }
+    },
     scripts=[
-        'bin/uefi-firmware-parser',
+        "bin/uefi-firmware-parser",
     ],
-    install_requires=['future'],
+    install_requires=["future"],
     classifiers=[
         # https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: System Administrators',
-        'Topic :: Security',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: System Administrators",
+        "Topic :: Security",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3",
     ],
     keywords="security uefi firmware parsing bios",
 )


### PR DESCRIPTION
Will solve future issues of non existent build for a certain (non free-threaded) python version.

Also, makes the build shorter and the releases smaller.
