### PR TITLE
fix(packaging): build abi3 extension with stable suffix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,15 +62,21 @@ for root, directory, paths in os.walk("uefi_firmware/compression"):
             COMPRESSION_SOURCES.append(os.path.join(root, path))
 
 IS_FREE_THREADED = sysconfig.get_config_var("Py_GIL_DISABLED") == 1
+USE_LIMITED_API = not IS_FREE_THREADED
 
-if IS_FREE_THREADED:
-    options = {}
-else:
+if USE_LIMITED_API:
+    extension_options = {
+        "define_macros": [("Py_LIMITED_API", "0x030A0000")],
+        "py_limited_api": True,
+    }
     options = {
         "bdist_wheel": {
             "py_limited_api": "cp310",
         }
     }
+else:
+    extension_options = {}
+    options = {}
 
 
 setup(
@@ -96,6 +102,7 @@ setup(
             sources=COMPRESSION_SOURCES,
             include_dirs=[os.path.join("uefi_firmware", "compression", "Include")],
             depends=COMPRESSION_HEADERS,
+            **extension_options,
         )
     ],
     python_requires=">=3.10",

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -1,10 +1,31 @@
-import unittest
+import importlib.machinery
+import os
 import struct
+import sysconfig
+import unittest
 
 from uefi_firmware import efi_compressor
 
 
 class CompressionTest(unittest.TestCase):
+
+    def test_extension_uses_abi3_suffix(self):
+        if sysconfig.get_config_var("Py_GIL_DISABLED") == 1:
+            self.skipTest("free-threaded CPython does not use abi3 wheels")
+
+        abi3_suffix = None
+        for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+            if ".abi3" in suffix or suffix == ".pyd":
+                abi3_suffix = suffix
+                break
+
+        if abi3_suffix is None:
+            self.skipTest("interpreter does not advertise an abi3 extension suffix")
+
+        self.assertEqual(
+            os.path.basename(efi_compressor.__file__),
+            "efi_compressor" + abi3_suffix,
+        )
 
     def _test_compress(self, compress_algorithm):
         default_buffer = b"AAAAAAAA" * 90

--- a/uefi_firmware/compression/EfiCompressor.c
+++ b/uefi_firmware/compression/EfiCompressor.c
@@ -119,7 +119,7 @@ UefiDecompress(
   UINT8       type
   )
 {
-  PyBytesObject *SrcData;
+  PyObject      *SrcData;
   SizeT         SrcDataSize;
   SizeT         DstDataSize;
   EFI_STATUS    Status;
@@ -134,7 +134,10 @@ UefiDecompress(
     return NULL;
   }
 
-  SrcBuf = SrcData->ob_sval;
+  SrcBuf = PyBytes_AsString(SrcData);
+  if (SrcBuf == NULL) {
+    return NULL;
+  }
 
   Status = Extract((VOID *)SrcBuf, SrcDataSize, (VOID **)&DstBuf, &DstDataSize, type);
   if (Status != EFI_SUCCESS) {
@@ -157,7 +160,7 @@ UefiCompress(
   UINT8       type
   )
 {
-  PyBytesObject *SrcData;
+  PyObject      *SrcData;
   SizeT         SrcDataSize;
   SizeT         DstDataSize;
   EFI_STATUS    Status;
@@ -176,7 +179,10 @@ UefiCompress(
     return NULL;
   }
 
-  SrcBuf = SrcData->ob_sval;
+  SrcBuf = PyBytes_AsString(SrcData);
+  if (SrcBuf == NULL) {
+    return NULL;
+  }
 
   if (type == LZMA_COMPRESSION) {
     // LzmaCompress takes a 5th DictionarySize parameter, so it cannot be
@@ -328,5 +334,4 @@ initefi_compressor(VOID) {
   Py_InitModule3("efi_compressor", EfiCompressor_Funcs, "Various EFI Compression Algorithms Extension Module");
 }
 #endif
-
 


### PR DESCRIPTION
Mark efi_compressor as a limited-API extension for cp310-abi3 wheels and use PyBytes_AsString instead of PyBytesObject internals. Add a regression test for the extension suffix.

Root cause: the `1.11` wheel was tagged `cp310-abi3`, but `setup.py` only set the wheel tag via `bdist_wheel.py_limited_api`; it did not mark the C extension itself as `py_limited_api` or define `Py_LIMITED_API`. The wheel therefore contained `efi_compressor.cpython-310-x86_64-linux-gnu.so`, which Python 3.13 will not load for an abi3 wheel. This has been reported through issue #152.

Patch summary: `setup.py` now builds `efi_compressor` as a real limited-API extension for non-free-threaded CPython, the C shim avoids `PyBytesObject` internals by using `PyBytes_AsString`, and `tests/test_compression.py` asserts the loaded extension uses the ABI3 suffix.

Verified: `python -m unittest tests.test_compression` passes. A clean PEP 517 wheel build produces `Tag: cp310-abi3-linux_x86_64` and contains `uefi_firmware/efi_compressor.abi3.so`.