### PR TITLE
Add safe_path utility and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -28,13 +30,13 @@ jobs:
         if [[ "${{ matrix.python-version }}" == "3"* ]]; then
           pip install --upgrade 'importlib-metadata > 4'
         fi
-        pip install .[tests]
+        pip install '.[tests]'
 
     - name: Clone public samples
       run: git clone https://github.com/theopolis/uefi-firmware-samples samples
 
     - name: Run unit tests
-      run: python -bb ./tests/test_compression.py
+      run: python -bb -m unittest discover -s tests
 
     - name: Run test script against all samples
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
       run: git clone https://github.com/theopolis/uefi-firmware-samples samples
 
     - name: Run unit tests
-      run: python -bb -m unittest discover -s tests
+      run: |
+        cd tests
+        python -bb -m unittest discover
 
     - name: Run test script against all samples
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
       # Used to host build
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
 
       - name: Install python-build
-        run: python -m pip install build>=0.10.0
+        run: python -m pip install 'build>=0.10.0'
 
       - name: Build sdist
         run: python -m build -s -o dist
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-python@v5
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel>=2.14.1
+        run: python -m pip install 'cibuildwheel>=2.14.1'
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist

--- a/tests/test_dump_paths.py
+++ b/tests/test_dump_paths.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+import unittest
+
+from uefi_firmware.utils import dump_data, safe_path, safe_path_component
+
+
+class DumpPathTest(unittest.TestCase):
+
+    def test_safe_path_component_removes_path_separators(self):
+        self.assertEqual(safe_path_component("../testing.partition"), ".._testing.partition")
+        self.assertEqual(safe_path_component("/tmp/testing.fv"), "_tmp_testing.fv")
+        self.assertEqual(safe_path_component("C:\\tmp\\testing.fv"), "C__tmp_testing.fv")
+        self.assertEqual(safe_path_component(".."), "_")
+
+    def test_safe_path_confines_untrusted_component_to_parent(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = os.path.join(temp_dir, "out")
+            target = safe_path(output_dir, "../testing.partition")
+
+            dump_data(target, b"test")
+
+            self.assertTrue(os.path.exists(os.path.join(output_dir, ".._testing.partition")))
+            self.assertFalse(os.path.exists(os.path.join(temp_dir, "testing.partition")))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/uefi_firmware/flash.py
+++ b/uefi_firmware/flash.py
@@ -77,9 +77,9 @@ class FlashRegion(FirmwareObject, BaseObject):
         pass
 
     def dump(self, parent=""):
-        dump_data(os.path.join(parent, "region-%s.fd" % self.name), self.data)
+        dump_data(safe_path(parent, "region-%s.fd" % self.name), self.data)
 
-        parent = os.path.join(parent, "region-%s" % self.name)
+        parent = safe_path(parent, "region-%s" % self.name)
         for section in self.sections:
             section.dump(parent)
         pass

--- a/uefi_firmware/me.py
+++ b/uefi_firmware/me.py
@@ -68,17 +68,17 @@ class MeObject(StructuredObject, FirmwareObject):
             print("")
 
     def dump_module(self, parent):
+        name = safe_path_component(self.name)
         if self.compression == COMP_TYPE_LZMA:
-            dump_data("%s.module.lzma" %
-                      os.path.join(parent, self.name), self.data)
+            dump_data(safe_path(parent, "%s.module.lzma" % name), self.data)
             try:
                 data = efi_compressor.LzmaDecompress(self.data, len(self.data))
-                dump_data("%s.module" % os.path.join(parent, self.name), data)
+                dump_data(safe_path(parent, "%s.module" % name), data)
             except Exception as e:
                 print("Cannot extract (%s), %s" % (self.name, str(e)))
                 return
         elif self.compression == COMP_TYPE_NOT_COMPRESSED:
-            dump_data("%s.module" % os.path.join(parent, self.name), self.data)
+            dump_data(safe_path(parent, "%s.module" % name), self.data)
 
 
 class MeModule(MeObject):
@@ -480,7 +480,8 @@ class MeManifestHeader(MeObject):
             module.dump(parent)
         if self.huffman_llut is not None:
             self.huffman_llut.dump(
-                os.path.join(parent, utf8_decode_safe(self.structure.PartitionName)))
+                safe_path(
+                    parent, utf8_decode_safe(self.structure.PartitionName)))
 
 
 class CPDEntry(MeObject):
@@ -629,10 +630,12 @@ class PartitionEntry(MeObject):
 
     def dump(self, parent=""):
         if self.has_content:
-            dump_data(os.path.join(parent, "%s.partition" % utf8_decode_safe(self.structure.Name)),
+            dump_data(safe_path(
+                parent, "%s.partition" % utf8_decode_safe(self.structure.Name)),
                 self.data)
         if self.manifest is not None:
-            self.manifest.dump(os.path.join(parent, utf8_decode_safe(self.structure.Name)))
+            self.manifest.dump(
+                safe_path(parent, utf8_decode_safe(self.structure.Name)))
 
 class MeContainer(MeObject):
 

--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -1660,11 +1660,11 @@ class FirmwareVolume(FirmwareObject):
         if len(self.data) == 0:
             return
 
-        path = os.path.join(parent, "volume-%s.fv" % self.name)
+        path = safe_path(parent, "volume-%s.fv" % self.name)
         dump_data(path, self._data)
 
         for _ffs in self.firmware_filesystems:
-            _ffs.dump(os.path.join(parent, "volume-%s" % self.name))
+            _ffs.dump(safe_path(parent, "volume-%s" % self.name))
 
 1
 class FirmwareCapsule(FirmwareObject):
@@ -1864,14 +1864,14 @@ class FirmwareCapsule(FirmwareObject):
         if len(self.data) == 0:
             return
 
-        path = os.path.join(parent, "capsule-%s.cap" % self.name)
+        path = safe_path(parent, "capsule-%s.cap" % self.name)
         dump_data(path, self._data)
 
         if self.capsule_body is not None:
             self.capsule_body.dump(
-                os.path.join(parent, "capsule-%s" % self.name))
+                safe_path(parent, "capsule-%s" % self.name))
         else:
             # Write the raw image data from the capsule.
-            path = os.path.join(parent, "capsule-%s.image" % self.name)
+            path = safe_path(parent, "capsule-%s.image" % self.name)
             offset = self.offsets["capsule_body"]
             dump_data(path, self.data[offset:offset + self.image_size])

--- a/uefi_firmware/utils.py
+++ b/uefi_firmware/utils.py
@@ -117,6 +117,29 @@ def bit_set(field, bit):
     return (field & bit == bit)
 
 
+def safe_path_component(component):
+    '''Return a filesystem-safe representation of a single path component.'''
+    if isinstance(component, bytes):
+        component = utf8_decode_safe(component)
+    else:
+        component = str(component)
+
+    component = component.replace('\x00', '')
+    for separator in ('/', '\\'):
+        component = component.replace(separator, '_')
+    component = component.replace(':', '_')
+
+    if component in ('', '.', '..'):
+        return '_'
+    return component
+
+
+def safe_path(parent, *components):
+    '''Join parent with sanitized path components.'''
+    return os.path.join(
+        parent, *[safe_path_component(part) for part in components])
+
+
 def dump_data(name, data):
     '''Write binary data to name.
 


### PR DESCRIPTION
The `safe_path` method should be used when a path name is constructed from data found in input. Otherwise, a path taken from caller input can be treated as-is.