### PR TITLE
Remove future dependency

### DIFF
--- a/scripts/fv_injector.py
+++ b/scripts/fv_injector.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import argparse
 
 from uefi_firmware.uefi import *

--- a/scripts/fv_injector.py
+++ b/scripts/fv_injector.py
@@ -7,13 +7,6 @@ from uefi_firmware.utils import dump_data, flatten_firmware_objects
 
 from uefi_firmware.pfs import PFSFile
 
-try:
-    import __builtin__
-
-    input = getattr(__builtin__, 'raw_input')
-except (ImportError, AttributeError):
-    pass
-
 
 def brute_search(data):
     volumes = search_firmware_volumes(data)

--- a/scripts/uefi_guids.py
+++ b/scripts/uefi_guids.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import argparse
 
 from uefi_firmware.uefi import *

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
     scripts=[
         "bin/uefi-firmware-parser",
     ],
-    install_requires=["future"],
+    install_requires=[],
     extras_require={
         "tests": ["dictdiffer"],
     },

--- a/uefi_firmware/me.py
+++ b/uefi_firmware/me.py
@@ -26,8 +26,6 @@
 
     3. This notice may not be removed or altered from any source distribution.
 '''
-from __future__ import print_function
-
 import ctypes
 import struct
 import os

--- a/uefi_firmware/misc/checker.py
+++ b/uefi_firmware/misc/checker.py
@@ -4,7 +4,6 @@ The TypeTester may be useful if parsing a large number of UEFI-related binaries.
 """
 
 
-from builtins import bytes
 import re
 
 from ..uefi import FirmwareVolume, FirmwareCapsule, FirmwareFile

--- a/uefi_firmware/uefi.py
+++ b/uefi_firmware/uefi.py
@@ -2,8 +2,6 @@
 This package defines firmware structures for unpacking, decompressing,
 extracting, and rebuilding UEFI data.
 '''
-from __future__ import print_function
-
 import gzip
 import logging
 import os

--- a/uefi_firmware/utils.py
+++ b/uefi_firmware/utils.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import os
 import sys
 import struct

--- a/uefi_firmware/utils.py
+++ b/uefi_firmware/utils.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import struct
-from builtins import bytes
 import binascii
 
 nocolor = False


### PR DESCRIPTION
The `future` dependency is no longer needed since this package targets recent python versions.

Replaces #148 